### PR TITLE
Add ErrorReportingAction

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ This library will log the exception with `Logger.error` before sending it to Sen
 
 # Using It
 
+## Dependency
+
 In your build.sbt
 ```
 libraryDependencies ++= Seq(
@@ -16,12 +18,30 @@ libraryDependencies ++= Seq(
 )
 ```
 
+## Configuration
+
 In your application.conf
 ```
 sentry.dsn=XX_PUT_YOUR_DSN_HERE_XX
 ```
 
 Note: If there is no `sentry.dsn` then reporting to sentry will be disabled, but the reporter will still log!
+
+## Use: Automatic
+
+You can use KPER's `ErrorReportingAction` in place of a normal `Action`:
+
+```scala
+import io.keen.error.ErrorReportingAction
+
+def foobar: Action[AnyContent] = ErrorReportingAction { request =>
+  // Whatever
+}
+```
+
+## Use: Manual
+
+Sometimes it's not convenient to use the `ErrorReportingAction` so you can use the `Reporter` directly:
 
 ```scala
 import io.keen.error.Reporter

--- a/src/main/scala/io/keen/error/ErrorReportingAction.scala
+++ b/src/main/scala/io/keen/error/ErrorReportingAction.scala
@@ -1,0 +1,23 @@
+package utils
+
+import scala.concurrent.Future
+import scala.util.{Failure,Success,Try}
+
+import play.api.mvc._
+import play.api.mvc.BodyParsers._
+import play.api.mvc.Results._
+
+import io.keen.error.Reporter
+
+object ErrorReportingAction extends ActionBuilder[Request] {
+
+  def invokeBlock[A](request: Request[A], block: (Request[A]) => Future[Result]): Future[Result] = {
+    Try(block(request)) match {
+      case Success(r) => r
+      case Failure(ex) => {
+        Reporter.logException(request, ex)
+        Future.successful(InternalServerError("NOK"))
+      }
+    }
+  }
+}


### PR DESCRIPTION
# What's This PR Do?

Adds an `ActionBuilder` for wrapping actions and catching the errors.
# Motivation

Makes things easier, and I was making one in each stupid application, so…
